### PR TITLE
fixing bug due to updated cat files

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,4 +9,4 @@ Depends: R (>= 3.4.1), datasets, graphics, grDevices, methods, stats, utils, sca
 License: MIT
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 6.1.1
+RoxygenNote: 7.1.1

--- a/R/worm_cat_controller.R
+++ b/R/worm_cat_controller.R
@@ -17,8 +17,6 @@
 #' @param zip_files Boolean If TRUE will create a zipped archive of the results
 #' @keywords worm cat
 #' @export
-#' @examples
-#' worm_cat_fun()
 worm_cat_fun <- function(file_to_process, title="rgs", output_dir=NULL, rm_dir=FALSE, annotation_file=NULL, input_type="Sequence.ID",
                         zip_files=TRUE){
     mainDir <- getwd()
@@ -31,14 +29,14 @@ worm_cat_fun <- function(file_to_process, title="rgs", output_dir=NULL, rm_dir=F
     if(!dir.exists(output_dir)){
         dir.create(file.path(mainDir, output_dir))
     }
-    
+
     if(is.null(annotation_file)){
         annotation_file="whole_genome_jul-03-2019.csv"
         worm_cat_annotations <- system.file("extdata", annotation_file, package="wormcat")
     } else {
         worm_cat_annotations <- annotation_file
     }
-    
+
     # Create the categories file
     .worm_cat_add_categories(file_to_process, output_dirPath, worm_cat_annotations, input_type)
 

--- a/R/worm_cat_controller.R
+++ b/R/worm_cat_controller.R
@@ -17,7 +17,7 @@
 #' @param zip_files Boolean If TRUE will create a zipped archive of the results
 #' @keywords worm cat
 #' @export
-worm_cat_fun <- function(file_to_process, title="rgs", output_dir=NULL, rm_dir=FALSE, annotation_file=NULL, input_type="Sequence.ID",
+worm_cat_fun <- function(file_to_process, title="rgs", output_dir=NULL, rm_dir=FALSE, annotation_file="whole_genome_jul-03-2019.csv", input_type="Sequence.ID",
                         zip_files=TRUE){
     mainDir <- getwd()
 
@@ -30,10 +30,8 @@ worm_cat_fun <- function(file_to_process, title="rgs", output_dir=NULL, rm_dir=F
         dir.create(file.path(mainDir, output_dir))
     }
 
-    if(is.null(annotation_file)){
-        annotation_file="whole_genome_jul-03-2019.csv"
-        worm_cat_annotations <- system.file("extdata", annotation_file, package="wormcat")
-    } else {
+    worm_cat_annotations <- system.file("extdata", annotation_file, package="wormcat")
+    if(!file.exists(worm_cat_annotations)){
         worm_cat_annotations <- annotation_file
     }
 

--- a/R/worm_cat_controller.R
+++ b/R/worm_cat_controller.R
@@ -13,22 +13,32 @@
 #' @param output_dir the output directory
 #' @param rm_dir Boolean If FALSE do not remove temp dir. If TRUE remove temp dir
 #' @param annotation_file 'straight_mmm-DD-YYYY.csv' or 'physiology_mmm-DD-YYYY.csv' the default is straight
-#' @param input_type 'Sequence ID' or 'Wormbase ID' the default is Sequence ID
+#' @param input_type 'Sequence.ID' or 'Wormbase.ID' the default is Sequence.ID
+#' @param zip_files Boolean If TRUE will create a zipped archive of the results
 #' @keywords worm cat
 #' @export
 #' @examples
 #' worm_cat_fun()
-worm_cat_fun <- function(file_to_process, title="rgs", output_dir=NULL, rm_dir=FALSE, annotation_file="physiology_jul-15-2018.csv", input_type="Sequence.ID"){
+worm_cat_fun <- function(file_to_process, title="rgs", output_dir=NULL, rm_dir=FALSE, annotation_file=NULL, input_type="Sequence.ID",
+                        zip_files=TRUE){
     mainDir <- getwd()
 
     if(is.null(output_dir)){
       output_dir <- paste("worm-cat_",format(Sys.time(), "%b-%d-%Y-%H:%M:%S"), sep="")
     }
     output_dirPath <- paste("./",output_dir, sep="")
-    dir.create(file.path(mainDir, output_dir))
 
-    worm_cat_annotations <- system.file("extdata", annotation_file, package="wormcat")
-
+    if(!dir.exists(output_dir)){
+        dir.create(file.path(mainDir, output_dir))
+    }
+    
+    if(is.null(annotation_file)){
+        annotation_file="whole_genome_jul-03-2019.csv"
+        worm_cat_annotations <- system.file("extdata", annotation_file, package="wormcat")
+    } else {
+        worm_cat_annotations <- annotation_file
+    }
+    
     # Create the categories file
     .worm_cat_add_categories(file_to_process, output_dirPath, worm_cat_annotations, input_type)
 
@@ -59,9 +69,10 @@ worm_cat_fun <- function(file_to_process, title="rgs", output_dir=NULL, rm_dir=F
 
     cat(runtime_l,annotation_file_l,input_type_l,file=run_data,sep="\n",append=TRUE)
 
-
-    files2zip <- dir(output_dirPath, full.names = TRUE)
-    zip(zipfile = output_dir, files = files2zip)
+    if(zip_files){
+        files2zip <- dir(output_dirPath, full.names = TRUE)
+        zip(zipfile = output_dir, files = files2zip)
+    }
     if(rm_dir == TRUE){
       print("cleaning up")
        unlink(output_dir, TRUE)

--- a/R/worm_cat_controller.R
+++ b/R/worm_cat_controller.R
@@ -17,8 +17,7 @@
 #' @param zip_files Boolean If TRUE will create a zipped archive of the results
 #' @keywords worm cat
 #' @export
-worm_cat_fun <- function(file_to_process, title="rgs", output_dir=NULL, rm_dir=FALSE, annotation_file="whole_genome_jul-03-2019.csv", input_type="Sequence.ID",
-                        zip_files=TRUE){
+worm_cat_fun <- function(file_to_process, title="rgs", output_dir=NULL, rm_dir=FALSE, annotation_file="whole_genome_jul-03-2019.csv", input_type="Sequence.ID", zip_files=TRUE){
     mainDir <- getwd()
 
     if(is.null(output_dir)){

--- a/R/worm_cat_fisher_test.R
+++ b/R/worm_cat_fisher_test.R
@@ -19,7 +19,7 @@ library("plyr")
 
   total_count <- data.frame(nrow(AC))
 
-  total_nrow <- rename(total_count, c("nrow.AC." = "nrow"))
+  total_nrow <- plyr::rename(total_count, c("nrow.AC." = "nrow"))
 
   total_annotated_cat1 <- data.frame(table(AC$Category.1))
 
@@ -31,7 +31,7 @@ library("plyr")
 
   RGS_count <- data.frame(nrow(RGS))
 
-  RGS_nrow <- rename(RGS_count, c("nrow.RGS." = "nrow"))
+  RGS_nrow <- plyr::rename(RGS_count, c("nrow.RGS." = "nrow"))
 
   RGS_annotated_cat1 <- data.frame(table(RGS$Category.1))
 
@@ -50,7 +50,7 @@ library("plyr")
 
   cat_a <- merge(UP_annotated_cat, total_annotated_cat, by = "Var1", all.x = TRUE)
 
-  cat_b <- rename(cat_a, c("Var1" = "Category", "Freq.x" = "RGS", "Freq.y" = "AC" ))
+  cat_b <- plyr::rename(cat_a, c("Var1" = "Category", "Freq.x" = "RGS", "Freq.y" = "AC" ))
 
   # Step 5: Build contengency table for each category in RGS vs AC
 

--- a/man/worm_cat_fun.Rd
+++ b/man/worm_cat_fun.Rd
@@ -4,9 +4,15 @@
 \alias{worm_cat_fun}
 \title{Worm Cat Function}
 \usage{
-worm_cat_fun(file_to_process, title = "rgs", output_dir = NULL,
-  rm_dir = FALSE, annotation_file = "physiology_jul-15-2018.csv",
-  input_type = "Sequence.ID")
+worm_cat_fun(
+  file_to_process,
+  title = "rgs",
+  output_dir = NULL,
+  rm_dir = FALSE,
+  annotation_file = NULL,
+  input_type = "Sequence.ID",
+  zip_files = TRUE
+)
 }
 \arguments{
 \item{file_to_process}{the file to be processes}
@@ -19,13 +25,12 @@ worm_cat_fun(file_to_process, title = "rgs", output_dir = NULL,
 
 \item{annotation_file}{'straight_mmm-DD-YYYY.csv' or 'physiology_mmm-DD-YYYY.csv' the default is straight}
 
-\item{input_type}{'Sequence ID' or 'Wormbase ID' the default is Sequence ID}
+\item{input_type}{'Sequence.ID' or 'Wormbase.ID' the default is Sequence.ID}
+
+\item{zip_files}{Boolean If TRUE will create a zipped archive of the results}
 }
 \description{
 This function takes a regulated gene set and the category annotations and runs a fisher test.
-}
-\examples{
-worm_cat_fun()
 }
 \keyword{cat}
 \keyword{worm}

--- a/man/worm_cat_fun.Rd
+++ b/man/worm_cat_fun.Rd
@@ -9,7 +9,7 @@ worm_cat_fun(
   title = "rgs",
   output_dir = NULL,
   rm_dir = FALSE,
-  annotation_file = NULL,
+  annotation_file = "whole_genome_jul-03-2019.csv",
   input_type = "Sequence.ID",
   zip_files = TRUE
 )


### PR DESCRIPTION
A few suggested fixes: 
**Necessary ones:** 
1) There was a bug in the worm_cat_fun since the default value was an annotation file that no longer existed in the package data. I updated the default in the function and also modified the code so that if the file is not found in the package data, it will treat the file name as a path to a file outside the package. This makes it possible to use more up to date files or even custom files. 
2) The function documentation was confusing as it referred to "Wormbase ID" and "Sequence ID" but if you don't use "Wormbase.ID" or "Sequence.ID" then the table join breaks. 

**Useful ones:**
3) worm_cat_fun will not try to create the output_dir unless it doesn't exist - makes it easier to rerun jobs and overwrite results.
4)  added option to worm_cat_fun to turn off creating a zipped archive (default behavior is the same as before)